### PR TITLE
feat: add syntax highlighting and default settings for cisco commands

### DIFF
--- a/ftplugin/cisco.lua
+++ b/ftplugin/cisco.lua
@@ -1,0 +1,8 @@
+require("config.coding.folding").addCommentStyle("cisco", {
+    line = "!"
+})
+
+vim.bo.tabstop = 2
+vim.bo.softtabstop = 2
+vim.bo.shiftwidth = 2
+vim.bo.commentstring = '!%s'

--- a/lua/config/lang.lua
+++ b/lua/config/lang.lua
@@ -6,3 +6,10 @@ vim.api.nvim_create_autocmd("BufEnter", {
         vim.opt.filetype = "terraform"
     end
 })
+
+vim.api.nvim_create_autocmd("BufEnter", {
+    pattern = { "*.cisco" },
+    callback = function ()
+        vim.opt.filetype = "cisco"
+    end
+})

--- a/lua/plugins/languages/cisco.lua
+++ b/lua/plugins/languages/cisco.lua
@@ -1,0 +1,9 @@
+return {
+    "momota/cisco.vim",
+    config = function()
+        -- Nothing to do - all this plugin does is adding some legacy vim syntax
+        -- configs that automatically apply to .cisco files.
+    end,
+    ft = { "cisco" },
+}
+

--- a/samples/cisco/sample.cisco
+++ b/samples/cisco/sample.cisco
@@ -1,0 +1,23 @@
+! Set hostname and password
+enable
+configure terminal
+! TODO: Change hostname
+hostname R-research-01
+line console 0
+password cisco
+login
+
+ipv6 unicast-routing
+
+interface Gig0/0/1
+no shutdown
+
+interface Gig0/0/1.10
+encapsulation dot1q 10
+ipv6 address 2001:9:9:10::1/64
+ipv6 address fe80::1 link-local
+
+interface Gig0/0/1.11
+encapsulation dot1q 11
+ipv6 address 2001:9:9:11::1/64
+ipv6 address fe80::1 link-local


### PR DESCRIPTION
Put cisco commands in a file named .cisco for it to take effect automatically.